### PR TITLE
Load air blocks as optimized air blocks

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/jsonmodels/ResourcepackBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/jsonmodels/ResourcepackBlockProvider.java
@@ -471,6 +471,8 @@ public class ResourcepackBlockProvider implements BlockProvider {
           .equals("minecraft:block/tinted_cross") || parentName.equals("block/cross") || parentName
           .equals("minecraft:block/cross")) {
         block.supportsOpacity = false;
+      } else if(blockDefinition.isEmpty()) {
+        return Air.INSTANCE;
       }
       try {
         while (!blockDefinition.get("parent").isUnknown()) {


### PR DESCRIPTION
So yeah, as we said on discord, load blocks without any model as air block to improve performances