### PR TITLE
Register a hit when the texture has an alpha a bit greater than 0

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/jsonmodels/QuadBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/jsonmodels/QuadBlock.java
@@ -47,7 +47,7 @@ public class QuadBlock extends Block {
           continue;
         }
         float[] color = textures[i].getColor(ray.u, ray.v);
-        if (color[3] > .99f) {
+        if (color[3] > Ray.EPSILON) {
           if (quads[i] instanceof TintedQuad) {
             float[] biomeColor = ray.getBiomeGrassColor(scene);
             color[0] *= biomeColor[0];


### PR DESCRIPTION
Fix the issue where blocks with semi transparent texture where completely invisible